### PR TITLE
02 get/campsites

### DIFF
--- a/api/crud/campsite_crud.py
+++ b/api/crud/campsite_crud.py
@@ -1,15 +1,19 @@
 #Create, Read, Update & Delete
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from api.models.campsite_models import Campsite
 from schemas.campsite_schemas import CampsiteCreate
 
-def get_campsites(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(Campsite).limit(limit).all()
+def fetch_campsites(db: Session, skip: int = 0, limit: int = 10):
+    campsites = db.query(Campsite).limit(limit).all()
+    return campsites
 
-def create_campsite(db: Session, campsite: CampsiteCreate):
+
+
+
+
+def insert_campsite(db: Session, campsite: CampsiteCreate):
     db_campsite = Campsite(
-        # campsite_id = campsite.campsite_id,
         campsite_name = campsite.campsite_name,
         campsite_longitude = campsite.campsite_longitude,
         campsite_latitude = campsite.campsite_longitude

--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 import uvicorn
 from os import getenv
 
-from crud.campsite_crud import get_campsites, create_campsite
+from crud.campsite_crud import fetch_campsites, insert_campsite
 from schemas.campsite_schemas import Campsite, CampsiteCreate
 from database.database import SessionLocal, engine, Base
 
@@ -24,14 +24,22 @@ def root():
 
 
 @app.get("/campsites", response_model=list[Campsite])
-def read_campsites(skip: int = 0, limit: int = 20, db: Session = Depends(get_db)):
-    campsites = get_campsites(db, skip=skip, limit=limit)
-    return campsites
+def get_campsites(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return fetch_campsites(db, skip=skip, limit=limit)
+
+
+
+
+
+
+
+
+
 
 
 @app.post("/campsites", response_model=Campsite)
-def create_campsite(campsite: CampsiteCreate, db: Session = Depends(get_db)):
-    return create_campsite(db=db, campsite=campsite)
+def post_campsite(campsite: CampsiteCreate, db: Session = Depends(get_db)):
+    return insert_campsite(db=db, campsite=campsite)
 
 if __name__ == "__main__":
     PORT = int(getenv('PORT', 8000))

--- a/api/models/campsite_models.py
+++ b/api/models/campsite_models.py
@@ -1,21 +1,21 @@
 from database.database import Base
+from typing import List
 from sqlalchemy import Boolean, Column, Integer, String, Float, ForeignKey
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column 
 
 
 class CampsiteCategory(Base):
     __tablename__ = "categories"
-
     category_id = Column(Integer, primary_key=True)
-    category_image_url = Column(String)
+    category_img_url = Column(String)
     category_name = Column(String)
+
 
 class Campsite(Base):
     __tablename__ = "campsites"
-
     campsite_id = Column(Integer, primary_key=True)
     campsite_name = Column(String, index=True)
-    category_id = Column(Integer, ForeignKey("categories.category_id"))
     campsite_longitude = Column(Float)
     campsite_latitude = Column(Float)
     parking_cost = Column(Float)
@@ -27,25 +27,30 @@ class Campsite(Base):
     added_by = Column(String)
     approved = Column(Boolean, default=False)
 
-    campsite_photos = relationship("CampsitePhoto", back_populates="photos")
-    campsite_contacts = relationship("CampsiteContact", back_populates="contacts")
+    category_id = Column(Integer, ForeignKey("categories.category_id"))
+    category = relationship("CampsiteCategory")
 
-class CampsitePhoto(Base):
-    __tablename__ = "campsite_photos"
+    contact: Mapped[List["CampsiteContact"]] = relationship("CampsiteContact", back_populates="campsite")
+    photos: Mapped[List["CampsitePhoto"]] = relationship("CampsitePhoto", back_populates="campsite")
 
-    campsite_photo_id = Column(Integer, primary_key=True)
-    campsite_photo_url = Column(String)
-    campsite_id = Column(Integer, ForeignKey("campsites.campsite_id"))
-
-    photos = relationship("Campsite", back_populates="campsite_photos")
 
 class CampsiteContact(Base):
     __tablename__ = "campsite_contacts"
-
     campsite_contact_id = Column(Integer, primary_key=True)
     campsite_contact_name = Column(String)
     campsite_contact_phone = Column(String)
     campsite_contact_email = Column(String)
-    campsite_id = Column(Integer, ForeignKey("campsites.campsite_id"))
 
-    contacts = relationship("Campsite", back_populates="campsite_contacts")
+    campsite_id = Column(Integer, ForeignKey("campsites.campsite_id"))
+    campsite: Mapped["Campsite"] = relationship("Campsite", back_populates="contact")
+
+
+class CampsitePhoto(Base):
+    __tablename__ = "campsite_photos"
+    campsite_photo_id = Column(Integer, primary_key=True)
+    campsite_photo_url = Column(String)
+
+    campsite_id = Column(Integer, ForeignKey("campsites.campsite_id"))
+    campsite: Mapped["Campsite"] = relationship("Campsite", back_populates="photos")
+
+

--- a/api/schemas/campsite_schemas.py
+++ b/api/schemas/campsite_schemas.py
@@ -15,42 +15,19 @@ class CampsitePhoto(CampsitePhotoBase):
     class ConfigDict:
         from_attributes = True
 
+
 class CampsiteContactBase(BaseModel):
     campsite_contact_name: str
     campsite_contact_phone: str
+    
 
 class CampsiteContactCreate(CampsiteContactBase):
-    campsite_contact_email: str
+    campsite_contact_email: str | None = None
 
 class CampsiteContact(CampsiteContactBase):
+    campsite_contact_email: str | None = None
     campsite_contact_id: int
     campsite_id: int
-
-    class ConfigDict: 
-        from_attributes = True
-
-class CampsiteBase(BaseModel):
-    campsite_name: str
-    campsite_longitude: float
-    campsite_latitude: float
-    parking_cost: float
-    facilities_cost: float
-    description: str
-    approved: bool = False
-
-class CampsiteCreate(CampsiteBase):
-    facilities: list[Facility] | None = None
-    activities: list[Activity] | None = None
-    contacts: list[CampsiteContact] | None = None
-    opening_month: str
-    closing_month: str
-
-class Campsite(CampsiteBase):
-    campsite_id: int
-    category_id: int
-    photos: list[CampsitePhoto] = []
-    date_added: str
-    added_by: str
 
     class ConfigDict: 
         from_attributes = True
@@ -58,10 +35,38 @@ class Campsite(CampsiteBase):
 
 class CampsiteCategoryBase(BaseModel):
     category_name: str
-    category_image_url: str
+    category_img_url: str
 
 class CampsiteCategoryCreate(CampsiteCategoryBase):
     pass
 
 class CampsiteCategory(CampsiteCategoryBase):
-    category_id: int
+    pass
+
+
+class CampsiteBase(BaseModel):
+    campsite_name: str
+    campsite_id: int
+    date_added: str
+    added_by: str
+    campsite_longitude: float
+    campsite_latitude: float
+    category: CampsiteCategory
+    photos: list[CampsitePhoto] = []
+    contact: list[CampsiteContact] = []
+    parking_cost: float | None = None
+    facilities_cost: float | None = None
+    description: str
+
+class CampsiteCreate(CampsiteBase):
+    facilities: list[Facility] | None = None
+    activities: list[Activity] | None = None
+    opening_month: str | None = None
+    closing_month: str | None = None
+
+class Campsite(CampsiteBase):
+    campsite_id: int
+    approved: bool = False
+
+    class ConfigDict: 
+        from_attributes = True

--- a/api/seed/dev_data.py
+++ b/api/seed/dev_data.py
@@ -11,15 +11,15 @@ def get_dev_data():
     return {
         'campsite_category': [
             CampsiteCategory(category_name="In The Wild",
-                             category_image_url="https://example.com/category1.jpg"),
+                             category_img_url="https://example.com/category1.jpg"),
             CampsiteCategory(category_name="Car Park",
-                             category_image_url="https://example.com/category2.jpg"),
+                             category_img_url="https://example.com/category2.jpg"),
             CampsiteCategory(category_name="Car Park - Daytime Only",
-                             category_image_url="https://example.com/category3.jpg"),
+                             category_img_url="https://example.com/category3.jpg"),
             CampsiteCategory(category_name="Campsite",
-                             category_image_url="https://example.com/category4.jpg"),
+                             category_img_url="https://example.com/category4.jpg"),
             CampsiteCategory(category_name="Free Motorhome Area",
-                             category_image_url="https://example.com/category5.jpg")
+                             category_img_url="https://example.com/category5.jpg")
         ],
         'facility': [
             Facility(facility_name="Wi-Fi",
@@ -90,7 +90,18 @@ def get_dev_data():
         ],
         'campsite_contact': [
             CampsiteContact(campsite_contact_id=1, campsite_id=1, campsite_contact_name="John Doe", campsite_contact_phone="123-456-7890"),
-            CampsiteContact(campsite_contact_id=2, campsite_id=2, campsite_contact_name="Jane Doe", campsite_contact_phone="987-654-3210")
+            CampsiteContact(campsite_contact_id=2, campsite_id=2, campsite_contact_name="Jane Doe", campsite_contact_phone="987-654-3210"),
+            CampsiteContact(campsite_contact_id=3, campsite_id=3, campsite_contact_name="Alice Smith", campsite_contact_phone="111-222-3333", campsite_contact_email="alice.smith@example.com"),
+            CampsiteContact(campsite_contact_id=4, campsite_id=4, campsite_contact_name="Bob Johnson", campsite_contact_phone="444-555-6666", campsite_contact_email="bob.johnson@example.com"),
+            CampsiteContact(campsite_contact_id=5, campsite_id=5, campsite_contact_name="Charlie Brown", campsite_contact_phone="777-888-9999", campsite_contact_email="charlie.brown@example.com"),
+            CampsiteContact(campsite_contact_id=6, campsite_id=6, campsite_contact_name="Diana Prince", campsite_contact_phone="000-111-2222", campsite_contact_email="diana.prince@example.com"),
+            CampsiteContact(campsite_contact_id=7, campsite_id=7, campsite_contact_name="Edward King", campsite_contact_phone="333-444-5555", campsite_contact_email="edward.king@example.com"),
+            CampsiteContact(campsite_contact_id=8, campsite_id=8, campsite_contact_name="Fiona Queen", campsite_contact_phone="666-777-8888", campsite_contact_email="fiona.queen@example.com"),
+            CampsiteContact(campsite_contact_id=9, campsite_id=9, campsite_contact_name="George Knight", campsite_contact_phone="999-000-1111", campsite_contact_email="george.knight@example.com"),
+            CampsiteContact(campsite_contact_id=10, campsite_id=10, campsite_contact_name="Hannah White", campsite_contact_phone="222-333-4444", campsite_contact_email="hannah.white@example.com"),
+            CampsiteContact(campsite_contact_id=11, campsite_id=11, campsite_contact_name="Ivy Green", campsite_contact_phone="555-666-7777", campsite_contact_email="ivy.green@example.com"),
+            CampsiteContact(campsite_contact_id=12, campsite_id=12, campsite_contact_name="Jack Black", campsite_contact_phone="888-999-0000", campsite_contact_email="jack.black@example.com"),
+            CampsiteContact(campsite_contact_id=13, campsite_id=13, campsite_contact_name="Karen Blue", campsite_contact_phone="123-321-4567", campsite_contact_email="karen.blue@example.com")
         ],
         'user': [
             User(username="NatureExplorer", user_password="secure123", user_firstname="Alice", user_lastname="Wanderlust", user_email="alice@example.com", xp=500, user_type="NORMAL", camera_permission=True),

--- a/api/tests/test_data.py
+++ b/api/tests/test_data.py
@@ -8,9 +8,9 @@ from api.models.user_models import User
 def get_test_data():
     return {
         'campsite_category': [
-            CampsiteCategory(category_name="In The Wild", category_image_url="https://example.com/category1.jpg"),
-            CampsiteCategory(category_name="Car Park", category_image_url="https://example.com/category2.jpg"),
-            CampsiteCategory(category_name="Campsite", category_image_url="https://example.com/category4.jpg")
+            CampsiteCategory(category_name="In The Wild", category_img_url="https://example.com/category1.jpg"),
+            CampsiteCategory(category_name="Car Park", category_img_url="https://example.com/category2.jpg"),
+            CampsiteCategory(category_name="Campsite", category_img_url="https://example.com/category4.jpg")
         ],
         'facility': [
             Facility(facility_name="Wi-Fi", facility_img_url="https://example.com/facility1.jpg"),
@@ -23,19 +23,17 @@ def get_test_data():
             Activity(activity_name="Bird Watching", activity_img_url="https://example.com/activity4.jpg")
         ],
         'campsite': [
-            Campsite(campsite_name="CAMPSITE A", category_id=1, campsite_longitude=-1.54322, campsite_latitude=53.45645, parking_cost=12, facilities_cost=25, description="CAMPSITE A offers a serene setting amidst lush greenery, ideal for a peaceful retreat.", date_added=datetime.now().isoformat(), added_by="Admin", approved=True),
-            Campsite(campsite_name="CAMPSITE B", category_id=2, campsite_longitude=-1.87654, campsite_latitude=53.54321, parking_cost=14, facilities_cost=27, description="CAMPSITE B provides stunning views and vibrant sunsets nestled on gentle slopes.", date_added=datetime.now().isoformat(), added_by="Admin", approved=True),
+            Campsite(campsite_name="CAMPSITE A", category_id=1, campsite_longitude=-1.54322, campsite_latitude=53.45645, parking_cost=None, facilities_cost=None, description="CAMPSITE A offers a serene setting amidst lush greenery, ideal for a peaceful retreat.", date_added=datetime.now().isoformat(), added_by="Admin", approved=True, opening_month="March", closing_month="November"),
+            Campsite(campsite_name="CAMPSITE B", category_id=2, campsite_longitude=-1.87654, campsite_latitude=53.54321, parking_cost=14, facilities_cost=27, description="CAMPSITE B provides stunning views and vibrant sunsets nestled on gentle slopes.", date_added=datetime.now().isoformat(), added_by="Admin", approved=False, opening_month=None, closing_month=None),
             Campsite(campsite_name="CAMPSITE C", category_id=3, campsite_longitude=-1.81234, campsite_latitude=53.123456, parking_cost=13, facilities_cost=26, description="CAMPSITE C offers prime access to river adventures in a picturesque setting.", date_added=datetime.now().isoformat(), added_by="Admin", approved=True)
         ],
         'campsite_photo': [
             CampsitePhoto(campsite_id=1, campsite_photo_url="https://example.com/photo1.jpg"),
-            CampsitePhoto(campsite_id=2, campsite_photo_url="https://example.com/photo2.jpg"),
-            CampsitePhoto(campsite_id=3, campsite_photo_url="https://example.com/photo3.jpg")
+            CampsitePhoto(campsite_id=2, campsite_photo_url="https://example.com/photo2.jpg")
         ],
         'campsite_contact': [
             CampsiteContact(campsite_contact_id=1, campsite_id=1, campsite_contact_name="John Doe", campsite_contact_phone="123-456-7890"),
-            CampsiteContact(campsite_contact_id=2, campsite_id=2, campsite_contact_name="Jane Doe", campsite_contact_phone="987-654-3210"),
-            CampsiteContact(campsite_contact_id=3, campsite_id=3, campsite_contact_name="Jack Doe", campsite_contact_phone="321-654-9870")
+            CampsiteContact(campsite_contact_id=3, campsite_id=3, campsite_contact_name="Jack Doe", campsite_contact_phone="321-654-9870", campsite_contact_email="abc@xyz.com")
         ],
         'review': [
             Review(rating=5, campsite_id=1, username="NatureExplorer", comment="Stunning location, completely serene. Can't wait to come back."),

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -56,17 +56,33 @@ def test_read_main():
 def test_read_campsites(test_db):
     response = client.get("/campsites")
     assert response.status_code == 200
-
     response_data = response.json()
+
     assert len(response_data) == 3
     for campsite in response_data:
         assert isinstance(campsite['campsite_name'], str)
-        assert isinstance(campsite['description'], str)
+        assert isinstance(campsite['campsite_id'], int)
+        assert is_valid_date(campsite['date_added'])
         assert isinstance(campsite['added_by'], str)
         assert isinstance(campsite['campsite_longitude'], float)
         assert isinstance(campsite['campsite_latitude'], float)
-        assert isinstance(campsite['campsite_id'], int)
-        assert isinstance(campsite['category_id'], int)
+        assert isinstance(campsite['category']['category_name'], str)
+        assert isinstance(campsite['category']['category_img_url'], str)
         assert isinstance(campsite['photos'], list)
-        assert isinstance(campsite['date_added'], str)
-        assert is_valid_date(campsite['date_added'])
+        assert isinstance(campsite['parking_cost'], (float, type(None)))
+        assert isinstance(campsite['facilities_cost'], (float, type(None)))
+        assert isinstance(campsite['description'], str)
+        assert isinstance(campsite['approved'], bool)
+        assert isinstance(campsite['contact'], list)
+
+        for photo in campsite['photos']:
+                assert isinstance(photo['campsite_photo_url'], str)
+                assert isinstance(photo['campsite_photo_id'], int)
+                assert isinstance(photo['campsite_id'], int)
+
+        for detail in campsite['contact']:
+            assert isinstance(detail['campsite_contact_name'], str)
+            assert isinstance(detail['campsite_contact_phone'], str)
+            assert isinstance(detail['campsite_contact_email'], (str, type(None)))
+            assert isinstance(detail['campsite_contact_id'], int)
+            assert isinstance(detail['campsite_id'], int)

--- a/api/tests/utils_tests/database_utils_tests/seed_database_test_data.py
+++ b/api/tests/utils_tests/database_utils_tests/seed_database_test_data.py
@@ -109,12 +109,12 @@ def get_complex_seed_test_data():
             CampsiteCategory(
                 category_id=1,
                 category_name="Mountain",
-                category_image_url="https://example.com/category1.jpg"
+                category_img_url="https://example.com/category1.jpg"
             ),
             CampsiteCategory(
                 category_id=2,
                 category_name="Beach",
-                category_image_url="https://example.com/category2.jpg"
+                category_img_url="https://example.com/category2.jpg"
             )
         ]
     }
@@ -122,9 +122,9 @@ def get_complex_seed_test_data():
 def get_complete_seed_test_data():
     return {
         'campsite_category': [
-            CampsiteCategory(category_name="In The Wild", category_image_url="https://example.com/category1.jpg"),
-            CampsiteCategory(category_name="Car Park", category_image_url="https://example.com/category2.jpg"),
-            CampsiteCategory(category_name="Campsite", category_image_url="https://example.com/category4.jpg")
+            CampsiteCategory(category_name="In The Wild", category_img_url="https://example.com/category1.jpg"),
+            CampsiteCategory(category_name="Car Park", category_img_url="https://example.com/category2.jpg"),
+            CampsiteCategory(category_name="Campsite", category_img_url="https://example.com/category4.jpg")
         ],
         'facility': [
             Facility(facility_name="Wi-Fi", facility_img_url="https://example.com/facility1.jpg"),


### PR DESCRIPTION
Completes GET /campsites endpoint:
- Expands existing TDD to full test suite after initial 'dummy' endpoint was made to learn basic Pytest syntax, and to develop basic project architecture in FastAPI and SQLAlcemhy
- adapts test data to better probe endpoint resilience
- develops endpoint in crud.py and main.py
- handles relationships and validation in Pydantic schemas and models
