### PR TITLE
Patch users/username

### DIFF
--- a/api/crud/user_crud.py
+++ b/api/crud/user_crud.py
@@ -15,6 +15,25 @@ def read_user_by_username(db, username):
     return user
 
 
+def update_user_xp(db, username, xp):
+    user = db.get(User, username)
+    if not user:
+        raise HTTPException(status_code=404, detail="404 - User Not Found!")
+
+    try:
+        if xp.startswith('-'):
+            xp_value = -int(xp[1:])
+        else:
+            xp_value = int(xp)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="400 - Invalid XP Value")
+
+    user.xp += xp_value
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 def create_user_favourite_campsite(db, username, campsite_id):
     user = db.query(User).filter(User.username == username).first()
     if not user:

--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from database.database import SessionLocal, engine, Base
 from api.crud.campsite_crud import create_campsite, read_campsites, read_campsite_by_id
 from api.crud.reviews_crud import create_review_by_campsite_id, read_reviews_by_campsite_id
-from api.crud.user_crud import create_user_favourite_campsite, read_users, read_user_by_username, read_user_campsite_favourites_by_username, remove_user_favourite_campsite
+from api.crud.user_crud import read_users, read_user_by_username, update_user_xp, create_user_favourite_campsite, read_user_campsite_favourites_by_username, remove_user_favourite_campsite
 from api.schemas.campsite_schemas import CampsiteCreateRequest, Campsite, CampsiteDetailed
 from api.schemas.review_schemas import Review, ReviewCreateRequest
 from api.schemas.user_schemas import User
@@ -70,6 +70,11 @@ def get_users(db: Session = Depends(get_db)):
 @app.get("/users/{username}", response_model=User)
 def get_user_by_id(username, db: Session = Depends(get_db)):
     return read_user_by_username(db, username)
+
+@app.patch("/users/{username}/{xp}", response_model=User)
+def patch_user_xp(username: str, xp: str, db: Session = Depends(get_db)):
+    return update_user_xp(db=db, username=username, xp=xp)
+
 
 
 @app.get("/users/{username}/favourites", response_model=list[Campsite])

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -161,6 +161,38 @@ class TestGetUserCampsiteFavourites:
 
 
 @pytest.mark.main
+class TestUpdateUserByUsername:
+    def test_patch_user_xp(self, test_db):
+        response1 = client.patch('/users/NatureExplorer/25')
+        update1 = response1.json()
+        assert response1.status_code == 200
+
+        response2 = client.patch('/users/NatureExplorer/100')
+        update2 = response2.json()
+        assert response2.status_code == 200
+
+        response3 = client.patch('/users/NatureExplorer/-325')
+        update3 = response3.json()
+        assert response3.status_code == 200
+
+        assert update1['xp'] == 525
+        assert update2['xp'] == 625
+        assert update3['xp'] == 300
+
+    def test_400_invalid_patch_request(self, test_db):
+        response = client.patch('/users/NatureExplorer/INVALID')
+        error = response.json()
+        assert response.status_code == 400
+        assert error['detail'] == "400 - Invalid XP Value"
+
+    def test_404_non_existing_user(self, test_db):
+        response = client.patch('/users/INVALID/50')
+        error = response.json()
+        assert response.status_code == 404
+        assert error['detail'] == "404 - User Not Found!"
+
+
+@pytest.mark.main
 class TestGetReviews:
     def test_read_reviews_by_campsite_id(self, test_db):
         response = client.get("/campsites/1/reviews")
@@ -523,7 +555,7 @@ class TestPostUserFavouriteCampsite:
         assert error['detail'] == '404 - Campsite Not Found!'
 
 
-@pytest.mark.current
+@pytest.mark.main
 class TestDeleteUserFavouriteCampsite:
     def test_delete_user_favourite_campsite(self, test_db):
         response = client.delete("/users/NatureExplorer/favourites/3")

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -466,6 +466,7 @@ class TestGetUserByUsername:
         error = response.json()
         assert error["detail"] == "404 - User Not Found!"
 
+
 @pytest.mark.main
 class TestUpdateUserXP:
     def test_patch_user_xp(self, test_db):


### PR DESCRIPTION
Creates PATCH users/username/xp endpoint
- creates TDD suite
-  creates endpoint
- users can patch xp by directly placing a positive or negative number (denoted by starting with '-') into the url path
- custom 400 bad request - invalid xp
- custom 404 user not found