### PR TITLE
Refactor get reviews crud

### DIFF
--- a/api/crud/reviews_crud.py
+++ b/api/crud/reviews_crud.py
@@ -32,8 +32,6 @@ def create_review_by_campsite_id(db, campsite_id: int, request: ReviewCreateRequ
 
 def read_reviews_by_campsite_id(db, id: int):
     reviews = db.query(Review).filter(Review.campsite_id == id).all()
-    if not reviews:
-        raise HTTPException(status_code=404, detail="404 - Reviews Not Found!")
     return reviews
 
 

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -437,10 +437,11 @@ class TestGetReviewsByCampsiteId:
         response = client.get("/campsites/2/reviews")
         assert response.status_code == 200
 
-    def test_404_reviews_not_found(self, test_db):
+    def test_return_empty_array_if_no_reviews(self, test_db):
         response = client.get("/campsites/987654321/reviews")
-        assert response.status_code == 404
-        assert response.json()["detail"] == "404 - Reviews Not Found!"
+        assert response.status_code == 200
+        reviews = response.json()
+        assert reviews == []
 
 
 @pytest.mark.main


### PR DESCRIPTION
Changes GET campsites/id/reviews endpoint behaviour to return empty array instead of 404 in case of no reviews for valdi campsite id